### PR TITLE
Fixed memory error in filter 4 (rectangular loess) 

### DIFF
--- a/source/spatial_filter.F90
+++ b/source/spatial_filter.F90
@@ -757,7 +757,7 @@ module spatial_filter
           jcol = par_jstart + j - 1
           start_pos = (j-1)*nx_global + 1
           
-          do i = 1, nx_global
+          do i = par_istart, par_iend
              i_mark = i - par_istart + 1
              if (kmt_global(i,jcol) > 0) then
                 lon = tlon_global(i,jcol) !in radians


### PR DESCRIPTION

### Description of changes:

Changed one line for filter = 4 (Rectangular loess filter) that affected cases when the number of ocn processors was at least twice as large than the number of grid points in the N-S direction (nx_global).

### Testing:
 
Test case/suite: 
Test status: bit for bit for lower proc counts (larger resulted in a crash).  Did not affect other filters (1-3).

Fixes [POP2 Github issue #]
N/A

User interface (namelist or namelist defaults) changes?
nope

